### PR TITLE
Allow for clients to set their own CA and client certs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ htmlcov
 venv
 __pycache__
 *.pyc
+.cache


### PR DESCRIPTION
- Abstracts out the Elasticsearch client configuration for testing
- Allows for the user to set environment variables for authenticating to Elasticsearch using a client certificate and key
- Allows for the user to configure a path to a custom certificate authority