### PR TITLE
Fix documentation typo for job_failures configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ watcher.alerts.slack:                   '@michael.russell,infra'              # 
 watcher.kibana_url                      'https://kibana.elastic.co'           # Base URl for generating links to Kibana
 watcher.docs:                           'https://example.com/HALP.md'         # Documentation link that will be included in the alert
 watcher.failures:                        12                                   # How many failed attempts need to have happened in the current window per pod (optional)
-watcher.jobfailures:                     2                                    # How many times a cronjob needs to fail in a row being an alert is sent (optional)
+watcher.job_failures:                    2                                    # How many times a cronjob needs to fail in a row being an alert is sent (optional)
 watcher.interval:                       '30s'                                 # How often the query is run (optional)
 watcher.reply_to                        'team@elastic.co,reply@elastic.o'     # Comma separated list of email addresses to use for the reply_to field in the email alerts
 watcher.throttle:                       600000                                # How often to send the alert in ms (optional)


### PR DESCRIPTION
Really impressed we went so long without noticing this one. It also
showed that Kuberwatcher doesn't nicely handle situations where missing
keys are being configured as well.