### PR TITLE
Replace pystache with chevron

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 pytest==3.2.3
 pytest-cov==2.5.1
-pystache==0.5.4
+chevron==0.14.0
 vcrpy==1.11.1

--- a/tests/kuberwatcher_test.py
+++ b/tests/kuberwatcher_test.py
@@ -1,5 +1,5 @@
 from kuberwatcher import *
-import pystache
+import chevron
 import pytest
 import vcr
 import certifi
@@ -12,7 +12,7 @@ my_vcr = vcr.VCR(
 )
 
 def mustache_render(template, event):
-    return pystache.render(template, {'ctx':{'payload':{'aggregations': {'result': {'hits': {'hits': {'0': {'_source': event }}}}}}}})
+    return chevron.render(template, {'ctx':{'payload':{'aggregations': {'result': {'hits': {'hits': {'0': {'_source': event }}}}}}}})
 
 def test_template_defaults_with_no_outputs():
     watch = {
@@ -340,7 +340,7 @@ def test_get_all_pods_with_pods_that_dont_have_created_by():
     assert 'nginx-pod' not in pods['replicaset']['test']
 
 def test_generate_watch():
-    pods = { 
+    pods = {
         'replicaset': {
             'test': {
                 'nginx': {}


### PR DESCRIPTION
Builds have been failing since November 11:
https://devops-ci.elastic.co/job/elastic+kuberwatcher+master/

It seems like pystache has been dead for a while and finally fallen
enough behind modern Python practices to no longer install cleanly.
Chevon seems to be a more up-to-date, drop-in replacement; it's only
used for tests. `make test` fails (it's likely it has been for a while),
but `CI=true make test` passes.