### PR TITLE
Cleanup old Watchers for removed workloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ default: build
 SHELL:=/bin/bash -eu
 export PATH := ./bin:./venv/bin:$(PATH)
 
-VERSION = 7.10.3
+VERSION = 7.11.0
 IMAGE = push.docker.elastic.co/kuberwatcher/kuberwatcher:${VERSION}
 STACK_VERSION = 7.1.1
 PASSWORD = changeme


### PR DESCRIPTION
This is a quick backwards compatible way to make sure Kuberwatcher
cleans up old alerts. Without this the amount of alerts will continuously
grow which can be problematic for workflows creating unique alert names.

An idea for a better more forward thinking implementation is to add
something like `metadata["kuberwatcher"]` to the alerts so that the
ownership can be clearly detected instead.